### PR TITLE
Update regex for better data cleaning

### DIFF
--- a/cc_markov.py
+++ b/cc_markov.py
@@ -17,7 +17,7 @@ class MarkovChain:
   def __init__(self, num_key_words=2):
     self.num_key_words = num_key_words
     self.lookup_dict = defaultdict(list)
-    self._punctuation_regex = re.compile('[,.!;\?\:\-\[\]\n]+')
+    self._punctuation_regex = re.compile('[,.!;\?\:\-\[\]\(\)\"\\\n]+')
     self._seeded = False
     self.__seed_me()
 

--- a/cc_markov.py
+++ b/cc_markov.py
@@ -17,7 +17,7 @@ class MarkovChain:
   def __init__(self, num_key_words=2):
     self.num_key_words = num_key_words
     self.lookup_dict = defaultdict(list)
-    self._punctuation_regex = re.compile('[,.!;\?\:\-\[\]\(\)\"\\\n]+')
+    self._punctuation_regex = re.compile('[/,.!;\?\:\-\[\]\(\)\"\\\n]+')
     self._seeded = False
     self.__seed_me()
 


### PR DESCRIPTION
The regex in cc_markov.py was set to clean data from most punctuation, but not parenthesis, forward slash, backslash, or double quote characters.  I updated the regex to clean the data more thoroughly from these characters.